### PR TITLE
Override eyes and mouth during active pet spam

### DIFF
--- a/face.js
+++ b/face.js
@@ -328,6 +328,12 @@ class ClaudeFace {
   }
 
   getEyes(theme, frame) {
+    if (this.petSpamActive) {
+      // L3: overstimulated vibrating eyes, L1-2: sparkle eyes
+      return this.petSpamLevel >= 3
+        ? eyes.vibrate(theme, frame)
+        : eyes.sparkle(theme, frame);
+    }
     if (this.petAfterglowTimer > 0) {
       return eyes.content(theme, frame);
     }
@@ -364,6 +370,9 @@ class ClaudeFace {
   }
 
   getMouth(theme, frame) {
+    if (this.petSpamActive) {
+      return this.petSpamLevel >= 2 ? mouths.grin() : mouths.wide();
+    }
     if (this.petAfterglowTimer > 0) return mouths.smile();
     switch (this.state) {
       case 'idle':      return mouths.smile();

--- a/test.js
+++ b/test.js
@@ -1848,6 +1848,46 @@ describe('face.js -- pet spam escalation', () => {
     // Should have seen multiple different thoughts in ~2 seconds
     assert.ok(thoughts.size > 1, 'level 3 thoughts should cycle rapidly');
   });
+
+  test('eyes override to sparkle during L1-2 spam (even in error state)', () => {
+    const face = new ClaudeFace();
+    face.state = 'error'; // normally cross eyes
+    for (let i = 0; i < 8; i++) face.pet();
+    assert.ok(face.petSpamActive);
+    const theme = face.getTheme();
+    const eyeResult = face.getEyes(theme, 0);
+    const sparkleEyes = eyes.sparkle(theme, 0);
+    assert.deepStrictEqual(eyeResult, sparkleEyes);
+  });
+
+  test('eyes override to vibrate during L3 spam', () => {
+    const face = new ClaudeFace();
+    face.state = 'idle';
+    for (let i = 0; i < 8; i++) face.pet();
+    for (let i = 0; i < 50; i++) face.update(66);
+    for (let i = 0; i < 8; i++) face.pet();
+    for (let i = 0; i < 50; i++) face.update(66);
+    for (let i = 0; i < 8; i++) face.pet();
+    assert.strictEqual(face.petSpamLevel, 3);
+    const theme = face.getTheme();
+    const eyeResult = face.getEyes(theme, 0);
+    const vibrateEyes = eyes.vibrate(theme, 0);
+    assert.deepStrictEqual(eyeResult, vibrateEyes);
+  });
+
+  test('mouth override to wide at L1, grin at L2+', () => {
+    const face = new ClaudeFace();
+    face.state = 'error'; // normally frown
+    for (let i = 0; i < 8; i++) face.pet();
+    assert.strictEqual(face.petSpamLevel, 1);
+    const theme = face.getTheme();
+    assert.strictEqual(face.getMouth(theme, 0), mouths.wide());
+    // Escalate to L2
+    for (let i = 0; i < 50; i++) face.update(66);
+    for (let i = 0; i < 8; i++) face.pet();
+    assert.strictEqual(face.petSpamLevel, 2);
+    assert.strictEqual(face.getMouth(theme, 0), mouths.grin());
+  });
 });
 
 // ====================================================================


### PR DESCRIPTION
Pet spam was only overriding thoughts/particles but leaving the face expression stuck in whatever state Claude was in. Now:
- L1-2: sparkle eyes + wide smile (star-eyed excitement)
- L2+: grin mouth (caffeinated-level intensity)
- L3: vibrating eyes (overstimulated, can't hold still)
- Afterglow: content (half-closed) eyes + gentle smile (unchanged)

The full expression arc is now: state-specific → sparkle/wide → sparkle/grin → vibrate/grin → content/smile → state-specific.

https://claude.ai/code/session_013pQBakmiRJ1opGqkzvN9GH