### PR TITLE
Orbital subagents: mini-faces orbit the main face

### DIFF
--- a/adapters/openclaw-adapter.js
+++ b/adapters/openclaw-adapter.js
@@ -122,6 +122,10 @@ process.stdin.on('end', () => {
       stats.daily.sessionCount++;
       stats.session = { id: sessionId, start: Date.now(), toolCalls: 0, filesEdited: [], subagentCount: 0 };
     }
+    if (!stats.session.activeSubagents) stats.session.activeSubagents = [];
+    stats.session.activeSubagents = stats.session.activeSubagents.filter(
+      sub => Date.now() - sub.startedAt < 600000
+    );
 
     if (stats.recentMilestone && Date.now() - stats.recentMilestone.at > 8000) {
       stats.recentMilestone = null;
@@ -173,6 +177,13 @@ process.stdin.on('end', () => {
       updateStreak(stats, state === 'error');
     }
     else if (event === 'turn_end') {
+      // Clean up synthetic subagent sessions
+      for (const sub of stats.session.activeSubagents) {
+        writeSessionState(sub.id, 'happy', 'done', true, {
+          sessionId: sub.id, stopped: true, cwd: '', parentSession: sessionId,
+        });
+      }
+      stats.session.activeSubagents = [];
       state = 'happy';
       detail = 'all done!';
       stopped = true;
@@ -187,14 +198,63 @@ process.stdin.on('end', () => {
       detail = 'needs attention';
     }
 
+    const isSubagentTool = SUBAGENT_TOOLS.test(toolName);
+
+    if ((event === 'tool_start' || event === 'PreToolUse') && isSubagentTool) {
+      const subId = `${sessionId}-sub-${Date.now()}`;
+      const desc = (toolInput.description || toolInput.prompt || 'subagent').slice(0, 40);
+      stats.session.activeSubagents.push({ id: subId, description: desc, startedAt: Date.now() });
+      writeSessionState(subId, 'thinking', desc, false, {
+        sessionId: subId, modelName: toolInput.model || 'openclaw', cwd: '', parentSession: sessionId,
+      });
+      state = 'subagent';
+      detail = `conducting ${stats.session.activeSubagents.length}`;
+    } else if ((event === 'tool_end' || event === 'PostToolUse') && isSubagentTool && stats.session.activeSubagents.length > 0) {
+      const finished = stats.session.activeSubagents.shift();
+      writeSessionState(finished.id, 'happy', 'done', true, {
+        sessionId: finished.id, stopped: true, cwd: '', parentSession: sessionId,
+      });
+      if (stats.session.activeSubagents.length > 0) {
+        state = 'subagent';
+        detail = `conducting ${stats.session.activeSubagents.length}`;
+      }
+    } else if (stats.session.activeSubagents.length > 0 && !isSubagentTool &&
+               event !== 'turn_end' && event !== 'waiting') {
+      const latestSub = stats.session.activeSubagents[stats.session.activeSubagents.length - 1];
+      writeSessionState(latestSub.id, state, detail, false, {
+        sessionId: latestSub.id, cwd: '', parentSession: sessionId,
+      });
+      state = 'subagent';
+      detail = `conducting ${stats.session.activeSubagents.length}`;
+    }
+
     extra.toolCalls = stats.session.toolCalls;
     extra.filesEdited = stats.session.filesEdited.length;
 
-    writeState(state, detail, extra);
+    // Guard global state file — don't let other sessions overwrite the owner
+    let shouldWriteGlobal = true;
+    try {
+      const existing = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+      if (existing.sessionId && existing.sessionId !== sessionId &&
+          !existing.stopped && Date.now() - (existing.timestamp || 0) < 120000) {
+        shouldWriteGlobal = false;
+      }
+    } catch {}
+
+    if (shouldWriteGlobal) writeState(state, detail, extra);
     writeSessionState(sessionId, state, detail, stopped, extra);
     writeStats(stats);
   } catch {
-    writeState('thinking');
+    // Guard global state file even in the fallback path
+    let shouldWriteGlobal = true;
+    try {
+      const existing = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+      if (existing.sessionId && existing.sessionId !== sessionId &&
+          !existing.stopped && Date.now() - (existing.timestamp || 0) < 120000) {
+        shouldWriteGlobal = false;
+      }
+    } catch {}
+    if (shouldWriteGlobal) writeState('thinking');
   }
 
   process.exit(0);

--- a/grid.js
+++ b/grid.js
@@ -43,6 +43,7 @@ class MiniFace {
     this.blinkFrame = -1;
     this.lookDir = 0;
     this.lookTimer = 0;
+    this.parentSession = null; // set if this is a synthetic subagent
   }
 
   updateFromFile(data) {
@@ -52,6 +53,7 @@ class MiniFace {
     this.lastUpdate = data.timestamp || Date.now();
     if (data.cwd) this.cwd = data.cwd;
     if (data.modelName) this.modelName = data.modelName;
+    if (data.parentSession) this.parentSession = data.parentSession;
     if (data.stopped && !this.stopped) {
       this.stopped = true;
       this.stoppedAt = Date.now();
@@ -304,9 +306,10 @@ class OrbitalSystem {
   }
 
   calculateOrbit(cols, rows, mainPos) {
-    // Minimum ellipse semi-axes: must clear the main face box + padding
+    // Minimum ellipse semi-axes: must clear the main face box + decorations
+    // Vertical: face box + accessories/thought bubble above (~5 rows) + stats below (~4 rows)
     const minA = Math.floor(mainPos.w / 2) + Math.floor(MINI_W / 2) + 3;
-    const minB = Math.floor(mainPos.h / 2) + Math.floor(MINI_H / 2) + 2;
+    const minB = Math.floor(mainPos.h / 2) + Math.floor(MINI_H / 2) + 6;
 
     // Maximum: constrained by terminal edges from main face center
     const maxA = Math.min(
@@ -340,6 +343,9 @@ class OrbitalSystem {
     const r = ansi.reset;
 
     for (const pos of positions) {
+      // Only draw connection lines to actual subagents, not independent sessions
+      if (pos.face && !pos.face.parentSession) continue;
+
       const dx = pos.col - mainPos.centerX;
       const dy = pos.row - mainPos.centerY;
       const steps = Math.max(Math.abs(dx), Math.abs(dy));
@@ -397,8 +403,9 @@ class OrbitalSystem {
     if (sorted.length === 0) return '';
 
     const SIDE_PAD = 2;
+    const SIDE_PAD_RIGHT = 16; // Extra clearance for thought bubbles extending right
     const leftCol = mainPos.col - MINI_W - SIDE_PAD;
-    const rightCol = mainPos.col + mainPos.w + SIDE_PAD;
+    const rightCol = mainPos.col + mainPos.w + SIDE_PAD_RIGHT;
     const canLeft = leftCol >= 1;
     const canRight = rightCol + MINI_W <= cols;
 
@@ -480,13 +487,14 @@ class OrbitalSystem {
     for (let i = 0; i < n; i++) {
       const angle = (Math.PI * 2 * i / n) + this.rotationAngle;
       const col = Math.round(mainPos.centerX + Math.cos(angle) * a - MINI_W / 2);
-      const row = Math.round(mainPos.centerY + Math.sin(angle) * b - MINI_H / 2);
+      // Shift orbit center down by 2 rows to account for thought bubbles/accessories above
+      const row = Math.round((mainPos.centerY + 2) + Math.sin(angle) * b - MINI_H / 2);
 
       // Clamp to terminal bounds
       const clampedCol = Math.max(1, Math.min(cols - MINI_W, col));
       const clampedRow = Math.max(1, Math.min(rows - MINI_H, row));
 
-      positions.push({ col: clampedCol, row: clampedRow });
+      positions.push({ col: clampedCol, row: clampedRow, face: visible[i] });
     }
 
     let buf = '';

--- a/tests/test-grid.js
+++ b/tests/test-grid.js
@@ -175,7 +175,8 @@ describe('grid.js -- OrbitalSystem calculateOrbit', () => {
     const result = orbital.calculateOrbit(120, 50, mainPos);
     // a should be at least mainPos.w/2 + MINI_W/2 + 3
     assert.ok(result.a >= Math.floor(mainPos.w / 2) + 4 + 3);
-    assert.ok(result.b >= Math.floor(mainPos.h / 2) + 3 + 2);
+    // b should be at least mainPos.h/2 + MINI_H/2 + 6 (extra for decorations)
+    assert.ok(result.b >= Math.floor(mainPos.h / 2) + 3 + 6);
   });
 });
 

--- a/update-state.js
+++ b/update-state.js
@@ -181,7 +181,7 @@ process.stdin.on('end', () => {
       // Clean up synthetic subagent sessions — main turn ended
       for (const sub of stats.session.activeSubagents) {
         writeSessionState(sub.id, 'happy', 'done', true, {
-          sessionId: sub.id, stopped: true, cwd: '',
+          sessionId: sub.id, stopped: true, cwd: '', parentSession: sessionId,
         });
       }
       stats.session.activeSubagents = [];
@@ -208,7 +208,7 @@ process.stdin.on('end', () => {
       const desc = (toolInput.description || toolInput.prompt || 'subagent').slice(0, 40);
       stats.session.activeSubagents.push({ id: subId, description: desc, startedAt: Date.now() });
       writeSessionState(subId, 'thinking', desc, false, {
-        sessionId: subId, modelName: toolInput.model || 'haiku', cwd: '',
+        sessionId: subId, modelName: toolInput.model || 'haiku', cwd: '', parentSession: sessionId,
       });
       state = 'subagent';
       detail = `conducting ${stats.session.activeSubagents.length}`;
@@ -216,7 +216,7 @@ process.stdin.on('end', () => {
       // Subagent finished — mark oldest synthetic session as stopped
       const finished = stats.session.activeSubagents.shift();
       writeSessionState(finished.id, 'happy', 'done', true, {
-        sessionId: finished.id, stopped: true, cwd: '',
+        sessionId: finished.id, stopped: true, cwd: '', parentSession: sessionId,
       });
       if (stats.session.activeSubagents.length > 0) {
         state = 'subagent';
@@ -227,7 +227,7 @@ process.stdin.on('end', () => {
       // Tool call from within a subagent — update latest synthetic session
       const latestSub = stats.session.activeSubagents[stats.session.activeSubagents.length - 1];
       writeSessionState(latestSub.id, state, detail, false, {
-        sessionId: latestSub.id, cwd: '',
+        sessionId: latestSub.id, cwd: '', parentSession: sessionId,
         modelName: toolInput.model || data.model_name || process.env.CODE_CRUMB_MODEL || 'claude',
       });
       // Main face stays in conducting mode


### PR DESCRIPTION
## Summary

- **Replaces grid mode with orbital system** — subagent sessions now appear as animated mini-faces orbiting the main ClaudeFace on an elliptical path, instead of a separate grid layout
- **Synthetic subagent tracking** — when Task/subagent tools fire, synthetic session files are created so the orbital system picks them up as mini-faces, with proper cleanup on Stop or timeout
- **Cross-editor support** — all four adapters (codex-wrapper, codex-notify, opencode, openclaw) now include sessionId and synthetic subagent tracking
- **Smart layout** — side panel mode for small terminals, connection lines with pulse animation between main face and subagents (not peer sessions), conducting eye/mouth animations, `o` key toggle
- **Responding state fix** — Stop hook now writes `responding` with a brief teal animation before transitioning to `happy`

## Changes

- `grid.js` — new `OrbitalSystem` with elliptical orbits, connection lines, conducting animation
- `face.js` — orbital toggle, conducting state integration
- `update-state.js` — synthetic subagent session files, state file ownership guard
- `renderer.js` — unified mode replacing grid mode, side panel fallback
- `adapters/*` — sessionId + synthetic subagent support in all adapters
- `animations.js`, `particles.js` — conducting animations, stream particle style
- `tests/test-grid.js` — expanded from ~60 to ~270 tests covering orbitals
- `CLAUDE.md`, `README.md` — updated docs

## Test plan

- [ ] `npm test` — all ~390 tests pass
- [ ] `npm start` + `npm run demo:orbital` — verify orbital animation, connection lines, side panel fallback on small terminals
- [ ] `npm start` + `npm run demo` — verify single-face mode still works, responding state shows teal face
- [ ] Press `o` to toggle orbital visibility, verify preference persists
- [ ] Resize terminal below 80x30 — verify graceful side panel degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)