### PR TITLE
Add quit flag to prevent renderer relaunch after user exits

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -17,6 +17,7 @@ const STATS_FILE = path.join(HOME, '.code-crumb-stats.json');
 const PREFS_FILE = path.join(HOME, '.code-crumb-prefs.json');
 const TEAMS_DIR = path.join(HOME, '.claude', 'teams');
 const PID_FILE = path.join(HOME, '.code-crumb.pid');
+const QUIT_FLAG_FILE = path.join(HOME, '.code-crumb-quit');
 const TMUX_FILE = path.join(HOME, '.code-crumb-tmux');
 
 // -- Utilities -------------------------------------------------------
@@ -103,4 +104,4 @@ function getGitBranch(cwd) {
   return null;
 }
 
-module.exports = { HOME, STATE_FILE, SESSIONS_DIR, STATS_FILE, PREFS_FILE, PID_FILE, TEAMS_DIR, TMUX_FILE, safeFilename, loadPrefs, savePrefs, getGitBranch, getIsWorktree };
+module.exports = { HOME, STATE_FILE, SESSIONS_DIR, STATS_FILE, PREFS_FILE, PID_FILE, QUIT_FLAG_FILE, TEAMS_DIR, TMUX_FILE, safeFilename, loadPrefs, savePrefs, getGitBranch, getIsWorktree };

--- a/update-state.js
+++ b/update-state.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { STATE_FILE, SESSIONS_DIR, STATS_FILE, PREFS_FILE, PID_FILE, safeFilename, getGitBranch, getIsWorktree } = require('./shared');
+const { STATE_FILE, SESSIONS_DIR, STATS_FILE, PREFS_FILE, PID_FILE, QUIT_FLAG_FILE, safeFilename, getGitBranch, getIsWorktree } = require('./shared');
 const {
   toolToState, classifyToolResult, updateStreak, defaultStats,
   EDIT_TOOLS,
@@ -75,6 +75,9 @@ function ensureRendererRunning() {
     let prefs = {};
     try { prefs = JSON.parse(fs.readFileSync(PREFS_FILE, 'utf8')); } catch {}
     if (!prefs.autolaunch) return;
+
+    // Check quit flag — user intentionally quit, don't auto-relaunch
+    try { fs.accessSync(QUIT_FLAG_FILE); return; } catch {}
 
     // Check if renderer alive via PID file
     try {


### PR DESCRIPTION
When the user presses q or Ctrl+C, renderer writes ~/.code-crumb-quit. ensureRendererRunning() checks for this flag and skips auto-relaunch. Clearing the flag on next manual startup restores normal autolaunch.