### PR TITLE
Fix fallback catch block always-false sessionId comparison (#69)

### DIFF
--- a/update-state.js
+++ b/update-state.js
@@ -456,14 +456,15 @@ process.stdin.on('end', () => {
     // non-JSON stdin -- still write the correct state for the hook event.
     // Try to reuse the session ID from the global state file so we don't
     // create an orphan session file that appears as a phantom orbital.
-    let fallbackSessionId = process.env.CLAUDE_SESSION_ID || String(process.ppid);
+    const originalFallbackId = process.env.CLAUDE_SESSION_ID || String(process.ppid);
+    let fallbackSessionId = originalFallbackId;
     let shouldWriteGlobal = true;
     try {
       const existing = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
       if (existing.sessionId) {
         fallbackSessionId = existing.sessionId;
       }
-      if (existing.sessionId && existing.sessionId !== fallbackSessionId &&
+      if (existing.sessionId && existing.sessionId !== originalFallbackId &&
           !existing.stopped && Date.now() - (existing.timestamp || 0) < 120000) {
         shouldWriteGlobal = false;
       }


### PR DESCRIPTION
The fallback catch block (for Stop/Notification with empty stdin) set
fallbackSessionId = existing.sessionId then immediately compared them,
making the subagent isolation check always pass. This let subagent Stop
events overwrite the main session's global state file.

Fix: preserve the original fallback ID before adopting the existing
session ID, and compare against that original value.

https://claude.ai/code/session_01Jjdix7fPJnbaPt4FkM8YPY