### PR TITLE
Fix #62: remove duplicate sessionCount increment

### DIFF
--- a/update-state.js
+++ b/update-state.js
@@ -347,8 +347,7 @@ process.stdin.on('end', () => {
     else if (hookEvent === 'SessionStart') {
       state = 'idle';
       detail = 'session starting';
-      // Force-initialize a fresh session
-      stats.daily.sessionCount++;
+      // sessionCount already incremented in new-session block above
       stats.session = {
         id: sessionId, start: Date.now(),
         toolCalls: 0, filesEdited: [], subagentCount: 0, commitCount: 0,


### PR DESCRIPTION
## Summary
- SessionStart was double-incrementing `stats.daily.sessionCount` — once in the general new-session block and again in the SessionStart handler
- Removed the duplicate increment from the SessionStart handler

## Test plan
- [x] All 699 tests pass
- [ ] Verify session count displays correctly after multiple sessions

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm