### PR TITLE
Fix #65: treat EPERM as process-exists in PID guard

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -78,7 +78,10 @@ function isAlreadyRunning() {
     if (isNaN(pid)) return false;
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err) {
+    if (err.code === 'EPERM') {
+      return true;
+    }
     return false;
   }
 }

--- a/tests/test-adapters.js
+++ b/tests/test-adapters.js
@@ -1098,6 +1098,12 @@ describe('bug fix regressions', () => {
     assert.ok(!src.includes('!isSubagentTool'),
       '!isSubagentTool guard should be gone (state-mirroring block removed)');
   });
+
+  test('renderer.js PID guard handles EPERM as running (#65)', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'renderer.js'), 'utf8');
+    assert.ok(src.includes("err.code === 'EPERM'"),
+      'PID guard catch should check for EPERM and treat as running');
+  });
 });
 
 module.exports = { passed: () => passed, failed: () => failed };


### PR DESCRIPTION
## Summary
- On Windows, `process.kill(pid, 0)` throws EPERM when the process exists but belongs to a different user/session
- The catch block now checks `err.code === 'EPERM'` and returns true (process is running)
- Prevents duplicate renderer instances on Windows

## Test plan
- [x] All 699 tests pass
- [ ] Verify two renderers can't start simultaneously on Windows

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm