### PR TITLE
Fix #70: stopped orbitals transition to idle after linger

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -169,7 +169,7 @@ class MiniFace {
     const sessionActive = !this.stopped;
 
     if (completionLinger && elapsed > completionLinger) {
-      this.state = 'thinking';
+      this.state = sessionActive ? 'thinking' : 'idle';
       this.minDisplayUntil = now + 1500;
     } else if (this.state === 'thinking' &&
                elapsed > (sessionActive ? THINKING_TIMEOUT : IDLE_TIMEOUT)) {

--- a/tests/test-grid.js
+++ b/tests/test-grid.js
@@ -670,4 +670,28 @@ describe('grid.js -- MiniFace updateFromFile detail gating (Bug 3)', () => {
   });
 });
 
+describe('grid.js -- completion linger respects sessionActive (#70)', () => {
+  test('stopped session decays to idle after completion linger', () => {
+    const face = new MiniFace('test');
+    face.state = 'happy';
+    face.stopped = true;
+    face.lastUpdate = Date.now() - 9000;
+    face.minDisplayUntil = 0;
+    face.tick(16);
+    assert.strictEqual(face.state, 'idle',
+      'stopped session should decay to idle, not thinking');
+  });
+
+  test('active session decays to thinking after completion linger', () => {
+    const face = new MiniFace('test');
+    face.state = 'happy';
+    face.stopped = false;
+    face.lastUpdate = Date.now() - 9000;
+    face.minDisplayUntil = 0;
+    face.tick(16);
+    assert.strictEqual(face.state, 'thinking',
+      'active session should decay to thinking');
+  });
+});
+
 module.exports = { passed: () => passed, failed: () => failed };


### PR DESCRIPTION
## Summary
- MiniFace completion linger timeout unconditionally transitioned to `thinking` even for stopped sessions
- Now checks `this.stopped` and transitions to `idle` instead, matching the main face behavior

## Test plan
- [x] All 699 tests pass
- [ ] Visual: finished subagent orbitals should go idle, not briefly reanimate as thinking

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm