### PR TITLE
Fix #71: use read time for orbital elapsed calculations

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -97,7 +97,7 @@ class MiniFace {
       this.minDisplayUntil = now + 1500;
       this.detail = data.detail || '';
     }
-    this.lastUpdate = data.timestamp || Date.now();
+    this.lastUpdate = Date.now();
     if (data.cwd) this.cwd = data.cwd;
     if (data.modelName) this.modelName = data.modelName;
     if (data.parentSession) this.parentSession = data.parentSession;

--- a/tests/test-grid.js
+++ b/tests/test-grid.js
@@ -694,4 +694,23 @@ describe('grid.js -- completion linger respects sessionActive (#70)', () => {
   });
 });
 
+describe('grid.js -- lastUpdate uses Date.now() not data.timestamp (#71)', () => {
+  test('lastUpdate is set to current time regardless of data.timestamp', () => {
+    const face = new MiniFace('test');
+    const staleTimestamp = Date.now() - 300000;
+    const before = Date.now();
+    face.updateFromFile({ state: 'coding', timestamp: staleTimestamp });
+    assert.ok(face.lastUpdate >= before,
+      'lastUpdate should use Date.now(), not stale data.timestamp');
+  });
+
+  test('lastUpdate is set even without data.timestamp', () => {
+    const face = new MiniFace('test');
+    const before = Date.now();
+    face.updateFromFile({ state: 'reading' });
+    assert.ok(face.lastUpdate >= before,
+      'lastUpdate should be set even with no timestamp in data');
+  });
+});
+
 module.exports = { passed: () => passed, failed: () => failed };


### PR DESCRIPTION
## Summary
- `MiniFace.updateFromFile()` was using `data.timestamp` (file write time) for elapsed calculations
- On NTFS with 1s mtime granularity + 2s reload cycle, this inflated elapsed by 1-3 seconds
- Now uses `Date.now()` (read time) so completion linger durations are accurate

## Test plan
- [x] All 699 tests pass
- [ ] Visual: orbital completion states should display for their full linger duration

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm