### PR TITLE
Fix #63: flush JSONL stream buffer on end

### DIFF
--- a/adapters/base-adapter.js
+++ b/adapters/base-adapter.js
@@ -173,6 +173,16 @@ function processStdinEvent(handler, fallbackFn) {
 
 function processJsonlStream(stream, handler) {
   let buffer = '';
+  const flush = () => {
+    if (buffer.trim()) {
+      try {
+        const event = JSON.parse(buffer);
+        handler(event);
+      } catch {
+        // Not valid JSON, skip
+      }
+    }
+  };
   stream.on('data', (chunk) => {
     buffer += chunk.toString();
     const lines = buffer.split(/\r?\n/);
@@ -187,6 +197,7 @@ function processJsonlStream(stream, handler) {
       }
     }
   });
+  stream.on('end', flush);
 }
 
 // -- Full stdin-based adapter runner -----------------------------------


### PR DESCRIPTION
## Summary
- `processJsonlStream` held incomplete lines in a buffer but never flushed on stream end
- If the last JSONL event had no trailing newline (common), it was silently dropped
- Added `stream.on('end', flush)` handler to process remaining buffer content

## Test plan
- [x] All 699 tests pass
- [ ] Verify Codex adapter captures final stop/completion events

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm