### PR TITLE
Fix #67: responding state visible for 3s instead of one frame

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -228,7 +228,7 @@ function runUnifiedMode() {
       face.transitionFrame = 0;
       face.lastStateChange = now;
       face.stateDetail = 'wrapping up';
-      face.minDisplayUntil = now; // expire immediately so happy fires next frame
+      face.minDisplayUntil = now + 3000; // respect responding's 3s min display time
       face.pendingState = null;
       face.pendingDetail = '';
       face.particles.fadeAll();
@@ -258,7 +258,7 @@ function runUnifiedMode() {
             face.transitionFrame = 0;
             face.lastStateChange = now;
             face.stateDetail = freshData.detail || 'wrapping up';
-            face.minDisplayUntil = now;
+            face.minDisplayUntil = now + 3000; // respect responding's 3s min display time
             face.pendingState = null;
             face.pendingDetail = '';
             face.particles.fadeAll();

--- a/tests/test-adapters.js
+++ b/tests/test-adapters.js
@@ -1104,6 +1104,19 @@ describe('bug fix regressions', () => {
     assert.ok(src.includes("err.code === 'EPERM'"),
       'PID guard catch should check for EPERM and treat as running');
   });
+
+  test('renderer.js responding state gets 3000ms minDisplayUntil (#67)', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'renderer.js'), 'utf8');
+    // Both occurrences of the responding→happy transition should use now + 3000
+    const matches = src.match(/minDisplayUntil = now \+ 3000;.*responding/g)
+                 || src.match(/now \+ 3000;.*3s min display/g)
+                 || [];
+    // Source-level check: no `now;` (immediate expire) near 'wrapping up'
+    assert.ok(!src.includes("minDisplayUntil = now;"),
+      'responding should not use minDisplayUntil = now (immediate expire)');
+    assert.ok(src.includes("now + 3000"),
+      'responding transitions should use now + 3000');
+  });
 });
 
 module.exports = { passed: () => passed, failed: () => failed };


### PR DESCRIPTION
## Summary
- The stopped-flag rescue block was setting `minDisplayUntil = now`, causing the responding "wrapping up" animation to flash for one frame (~66ms) before auto-transitioning to happy
- Changed to `now + 3000` to respect responding's 3-second min display time

## Test plan
- [x] All 699 tests pass
- [ ] Visual: "wrapping up" animation should be visible for ~3 seconds before happy face

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm