### PR TITLE
Fix #75: clean up stale session files on SessionStart

### DIFF
--- a/update-state.js
+++ b/update-state.js
@@ -348,6 +348,9 @@ process.stdin.on('end', () => {
       state = 'idle';
       detail = 'session starting';
       // sessionCount already incremented in new-session block above
+      // Clean up any stale session file from previous session with same ID
+      const staleSessionFile = path.join(SESSIONS_DIR, safeFilename(sessionId) + '.json');
+      try { fs.unlinkSync(staleSessionFile); } catch {}
       stats.session = {
         id: sessionId, start: Date.now(),
         toolCalls: 0, filesEdited: [], subagentCount: 0, commitCount: 0,
@@ -484,6 +487,9 @@ process.stdin.on('end', () => {
     } else if (hookEvent === 'SessionStart') {
       fallbackState = 'waiting';
       fallbackDetail = 'session starting';
+      // Clean up any stale session file from previous session with same ID
+      const staleSessionFile = path.join(SESSIONS_DIR, safeFilename(fallbackSessionId) + '.json');
+      try { fs.unlinkSync(staleSessionFile); } catch {}
     } else if (hookEvent === 'SubagentStart') {
       fallbackState = 'subagent';
       fallbackDetail = 'spawning subagent';


### PR DESCRIPTION
## Summary
- If a previous session crashed without firing Stop, its session file persisted for 2 minutes as a phantom orbital
- SessionStart now deletes any existing session file for the current session ID in both the main and fallback code paths

## Test plan
- [x] All 699 tests pass
- [ ] Kill a renderer mid-session, restart — no phantom orbiter should appear

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OpenCode agent swarm