### PR TITLE
Fix synthetic orbital faces never being retired

### DIFF
--- a/tests/test-state-machine.js
+++ b/tests/test-state-machine.js
@@ -2766,14 +2766,18 @@ describe('update-state.js -- subagent session detection (isKnownSubagent)', () =
     );
   });
 
-  test('synthetic orbital cleanup retires spawning files', () => {
+  test('synthetic orbital cleanup retires non-stopped files (not just spawning)', () => {
     const src = readSrc();
-    // The cleanup block should find spawning synthetics and mark them stopped
+    // The cleanup block should find non-stopped synthetics and mark them stopped.
+    // Must NOT require state === 'spawning' because _writeSubagentToolState
+    // changes the synthetic's state before the real subagent's first PreToolUse.
     const cleanupBlock = src.split('Retire synthetic orbital')[1];
     assert.ok(cleanupBlock, 'should have synthetic orbital cleanup comment');
     const cleanupContent = cleanupBlock.split('} catch {}')[0];
-    assert.ok(cleanupContent.includes("synthData.state === 'spawning'"),
-      'should check for spawning state when retiring synthetics');
+    assert.ok(!cleanupContent.includes("synthData.state === 'spawning'"),
+      'must NOT require spawning state — tool propagation changes it before retirement');
+    assert.ok(cleanupContent.includes('!synthData.stopped'),
+      'should check !synthData.stopped to retire any non-stopped synthetic');
     assert.ok(cleanupContent.includes("stopped: true"),
       'should mark synthetic as stopped');
   });
@@ -2852,7 +2856,7 @@ describe('update-state.js -- subagent session detection (isKnownSubagent)', () =
     const cleanupContent = cleanupBlock.split('}\n    }')[0];
     assert.ok(
       cleanupContent.includes('for (let i = 0; i < subs.length'),
-      'synthetic cleanup should iterate forward to retire oldest spawning face first'
+      'synthetic cleanup should iterate forward to retire oldest face first'
     );
     assert.ok(
       !cleanupContent.includes('subs.length - 1; i >= 0; i--'),

--- a/update-state.js
+++ b/update-state.js
@@ -568,19 +568,19 @@ process.stdin.on('end', () => {
     // blocks them from writing global state, and the renderer treats them as orbitals.
     if (isKnownSubagent) {
       extra.parentSession = stats.session.id;
-      // Retire synthetic orbital: SubagentStart created a synthetic file (spawning state).
+      // Retire synthetic orbital: SubagentStart created a synthetic file for the subagent.
       // Now that the real subagent is sending its own hooks, mark the synthetic as done
       // so it is pruned after STOPPED_LINGER_MS (10s) instead of lingering for STALE_MS (120s).
       // PreToolUse is the first tool event a real subagent sends -- retire on first contact.
       if (hookEvent === 'PreToolUse') {
         const subs = stats.session.activeSubagents;
-        // Iterate forward: oldest spawning synthetic is most likely to match
+        // Iterate forward: oldest non-stopped synthetic is most likely to match
         // the first real subagent hook when multiple subagents are concurrent.
         for (let i = 0; i < subs.length; i++) {
           try {
             const synthFp = path.join(SESSIONS_DIR, safeFilename(subs[i].id) + '.json');
             const synthData = JSON.parse(fs.readFileSync(synthFp, 'utf8'));
-            if (!synthData.stopped && synthData.state === 'spawning') {
+            if (!synthData.stopped) {
               if (synthData.taskDescription) extra.taskDescription = synthData.taskDescription;
               fs.writeFileSync(synthFp, JSON.stringify({
                 ...synthData, stopped: true, state: 'happy', detail: 'done',


### PR DESCRIPTION
## Summary

- Synthetic subagent files were never retired because `_writeSubagentToolState` changed their state from `spawning` before the real subagent's first `PreToolUse` could match them
- Removed the `spawning` state requirement from the retirement check — now only checks `!synthData.stopped`
- Each subagent was showing TWO orbital faces (synthetic + real) instead of one

## Test plan

- [x] All 1505 tests pass
- [ ] Visual: `npm start` — verify only one orbital per subagent, not two
- [ ] Dispatch subagents and confirm synthetics are retired within 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)