### PR TITLE
Fix multiline command text breaking face renderer layout

### DIFF
--- a/state-machine.js
+++ b/state-machine.js
@@ -136,7 +136,7 @@ function toolToState(toolName, toolInput) {
 
   // Strip ANSI escape sequences from detail before returning
   if (result.detail) {
-    result.detail = stripAnsi(result.detail);
+    result.detail = stripAnsi(result.detail).replace(/[\r\n]+/g, ' ');
   }
   return result;
 }
@@ -388,7 +388,7 @@ function classifyToolResult(toolName, toolInput, toolResponse, isErrorFlag) {
   }
 
   // Strip ANSI escape sequences from detail before returning
-  if (detail) detail = stripAnsi(detail);
+  if (detail) detail = stripAnsi(detail).replace(/[\r\n]+/g, ' ');
   return { state, detail, diffInfo };
 }
 


### PR DESCRIPTION
## Summary
- Commands containing newlines (heredocs, chained commands) caused detail text to escape the face box, rendering at column 1 on the next terminal line
- Added `\r\n` stripping to both detail sanitization sites in `state-machine.js` (`toolToState` and `classifyToolResult`)
- All three render paths (main face, orbital MiniFace, session list) are protected by this single source-level fix

## Test plan
- [x] All 1505 tests pass
- [ ] Visual: run `npm start`, trigger a multiline bash command — detail text stays inside the face box

🤖 Generated with [Claude Code](https://claude.com/claude-code)